### PR TITLE
Add https://travis-ci.org to keep track of build status.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+
+go:
+  - 1.4.1
+  - tip
+
+install: go get -v -t github.com/fogleman/pt/pt
+
+script:
+  - go test -v ./pt/... && go build ./pt
+  - go build examples/cornell.go
+  - go build examples/example1.go
+  - go build examples/example2.go
+  - go build examples/gopher.go
+  - go build examples/suzanne.go
+  - go build examples/teapot.go

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+## Status
+[![Build Status](https://travis-ci.org/gmlewis/pt.png)](https://travis-ci.org/gmlewis/pt)
+
 ### Summary
 
 I am writing a [path tracer](http://en.wikipedia.org/wiki/Path_tracing) in Go. The Go gopher below was rendered using it, and [here's the code](https://github.com/fogleman/pt/blob/master/examples/gopher.go) that was used to do it. It's 2560x1440px... so you can make it your wallpaper! The gopher 3D model was found [here](https://github.com/golang-samples/gopher-3d).


### PR DESCRIPTION
Hi Michael,

Here is a suggestion to add Travis CI to automatically build each github push so you can see if everything is still working properly.
You can see this in-action here: https://github.com/gmlewis/pt/tree/add-travis
and note the the build is currently failing.
You can get the details by clicking on the "failing" link and then click on either 7.1 (Go 1.4.1) or 7.2 (tip):
https://travis-ci.org/gmlewis/pt/jobs/49826626

You can create your own free Travis CI account and then change the "gmlewis" to "fogleman" and it will track your original repository instead of my fork.

I'm really looking forward to playing with this... thanks so much for writing it!

-- Glenn
